### PR TITLE
fix: Audit P0-P2 issues - actions, config paths, packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 <img src="https://img.shields.io/badge/docker-ready-blue?style=flat-square&logo=docker&logoColor=white" alt="Docker">
 <a href="https://mcp-tool-shop-org.github.io/tool-compass/"><img src="https://img.shields.io/badge/Landing_Page-live-blue?style=flat-square" alt="Landing Page"></a>
 
+
 *95% fewer tokens. Find tools by describing what you want to do.*
 
 [Installation](#quick-start) • [Usage](#usage) • [Docker](#option-2-docker) • [Performance](#performance) • [Contributing](#contributing)
@@ -56,6 +57,7 @@ ollama pull nomic-embed-text
 
 # Clone and setup
 git clone https://github.com/mcp-tool-shop-org/tool-compass.git
+
 cd tool-compass/tool_compass
 
 # Create virtual environment
@@ -80,6 +82,7 @@ python ui.py
 ```bash
 # Clone the repo
 git clone https://github.com/mcp-tool-shop-org/tool-compass.git
+
 cd tool-compass/tool_compass
 
 # Start with Docker Compose (requires Ollama running locally)
@@ -166,15 +169,53 @@ Returns:
 | `compass_sync(force)` | Rebuild index from backends |
 | `compass_audit()` | Full system report |
 
+### Progressive Disclosure Pattern
+
+Tool Compass uses a three-step progressive disclosure pattern to minimize token usage:
+
+```
+1. compass("your intent")     → Get tool name + short description (~100 tokens)
+2. describe("tool:name")      → Get full parameter schema (~500 tokens)
+3. execute("tool:name", args) → Run the tool
+```
+
+**Why this matters:**
+- Loading 77 tools upfront = ~38,500 tokens
+- Progressive disclosure = ~600 tokens per tool used
+- Savings: **95%+ for typical workflows**
+
+**Example workflow:**
+
+```python
+# Step 1: Find the right tool
+compass("generate an image from text")
+# Returns: comfy:comfy_generate (confidence: 0.91)
+
+# Step 2: Get the schema (only if needed)
+describe("comfy:comfy_generate")
+# Returns: Full parameter definitions, types, examples
+
+# Step 3: Execute
+execute("comfy:comfy_generate", {"prompt": "a sunset over mountains"})
+```
+
+The `hint` field in compass results guides this flow, suggesting when to use `describe()`.
+
 ## Configuration
 
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `TOOL_COMPASS_BASE_PATH` | Project root | Auto-detected |
 | `TOOL_COMPASS_PYTHON` | Python executable | Auto-detected |
-| `TOOL_COMPASS_CONFIG` | Config file path | `./compass_config.json` |
+| `TOOL_COMPASS_CONFIG` | Config file path | `~/.config/tool-compass/compass_config.json` |
+| `TOOL_COMPASS_DATA_DIR` | Data directory | Platform-specific (see below) |
 | `OLLAMA_URL` | Ollama server URL | `http://localhost:11434` |
 | `COMFYUI_URL` | ComfyUI server | `http://localhost:8188` |
+
+**Default data directories:**
+- **Windows:** `%LOCALAPPDATA%\tool-compass\`
+- **macOS:** `~/Library/Application Support/tool-compass/`
+- **Linux:** `~/.config/tool-compass/` (or `$XDG_CONFIG_HOME/tool-compass/`)
 
 See [`.env.example`](.env.example) for all options.
 
@@ -275,3 +316,4 @@ Tool Compass is a **local-first** development tool. See [SECURITY.md](SECURITY.m
 <p align="center">
   Built by <a href="https://mcp-tool-shop.github.io/">MCP Tool Shop</a>
 </p>
+

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 """
-Tool Compass - Setup Script
+Tool Compass - Bootstrap Script
 Run this to install dependencies and build the index.
+
+Usage:
+    python bootstrap.py
 """
 
 import subprocess

--- a/config.py
+++ b/config.py
@@ -368,26 +368,35 @@ def get_user_config_dir() -> Path:
        - Windows: %LOCALAPPDATA%/tool-compass
        - macOS: ~/Library/Application Support/tool-compass
        - Linux: ~/.config/tool-compass (or $XDG_CONFIG_HOME/tool-compass)
+    3. Fallback: .tool-compass in current working directory (if HOME unavailable)
     """
     env_dir = os.environ.get("TOOL_COMPASS_DATA_DIR")
     if env_dir:
         return Path(env_dir).resolve()
+
+    def _safe_home() -> Path:
+        """Get home directory with fallback for CI environments."""
+        try:
+            return Path.home()
+        except (RuntimeError, KeyError):
+            # HOME/USERPROFILE not set (common in CI)
+            return Path.cwd()
 
     if sys.platform == "win32":
         # Windows: use LOCALAPPDATA
         local_app_data = os.environ.get("LOCALAPPDATA")
         if local_app_data:
             return Path(local_app_data) / "tool-compass"
-        return Path.home() / "AppData" / "Local" / "tool-compass"
+        return _safe_home() / "AppData" / "Local" / "tool-compass"
     elif sys.platform == "darwin":
         # macOS: use Application Support
-        return Path.home() / "Library" / "Application Support" / "tool-compass"
+        return _safe_home() / "Library" / "Application Support" / "tool-compass"
     else:
         # Linux/Unix: use XDG_CONFIG_HOME or ~/.config
         xdg_config = os.environ.get("XDG_CONFIG_HOME")
         if xdg_config:
             return Path(xdg_config) / "tool-compass"
-        return Path.home() / ".config" / "tool-compass"
+        return _safe_home() / ".config" / "tool-compass"
 
 
 def get_config_path() -> Path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ exclude = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+pythonpath = ["."]  # Allow imports without sys.path.insert
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 addopts = "-v --tb=short"
@@ -114,7 +115,7 @@ markers = [
 source = ["."]
 omit = [
     "tests/*",
-    "setup.py",
+    "bootstrap.py",
     "archive/*",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,16 +4,14 @@ Tool Compass - Pytest Fixtures and Configuration
 Provides shared fixtures for testing the semantic search gateway.
 Based on FastMCP testing best practices:
 https://gofastmcp.com/patterns/testing
+
+Note: pythonpath is configured in pyproject.toml to allow direct imports.
 """
 
 import pytest
-import sys
 from pathlib import Path
 from unittest.mock import Mock, AsyncMock, patch
 import numpy as np
-
-# Add parent directory to path for imports
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from config import CompassConfig, StdioBackend
 from tool_manifest import ToolDefinition

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -6,9 +6,6 @@ Tests usage tracking, hot cache, and chain detection.
 
 import pytest
 from pathlib import Path
-import sys
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from analytics import HotToolEntry
 

--- a/tests/test_backend_client.py
+++ b/tests/test_backend_client.py
@@ -8,9 +8,6 @@ import pytest
 import asyncio
 from pathlib import Path
 from unittest.mock import Mock, AsyncMock, patch
-import sys
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from backend_client_mcp import (
     BackendConnection,

--- a/tests/test_chain_indexer.py
+++ b/tests/test_chain_indexer.py
@@ -10,9 +10,6 @@ import numpy as np
 from pathlib import Path
 from unittest.mock import Mock, AsyncMock, patch
 import sqlite3
-import sys
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from chain_indexer import (
     ChainIndexer,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,11 +5,8 @@ Tests cross-platform path handling and environment variable support.
 """
 
 import os
-import sys
 from pathlib import Path
 from unittest.mock import patch
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from config import (
     CompassConfig,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -172,40 +172,26 @@ class TestDefaultConfig:
     """Test default configuration generation."""
 
     def test_get_default_config_structure(self):
-        """Default config should have expected backends."""
+        """Default config should have empty backends (user must configure)."""
         config = get_default_config()
 
-        # Should have 5 backends
-        expected_backends = ["bridge", "comfy", "video", "chat", "doc"]
-        for name in expected_backends:
-            assert name in config.backends
-            assert isinstance(config.backends[name], StdioBackend)
+        # Default config ships with no backends - user must configure
+        assert config.backends == {}
+        assert config.embedding_model == "nomic-embed-text"
+        assert config.auto_sync is True
+        assert config.progressive_disclosure is True
 
     def test_get_default_config_uses_detected_python(self):
-        """Default config should use detected Python executable."""
+        """Default config has no backends; example config uses detected Python."""
         config = get_default_config()
-
-        for backend in config.backends.values():
-            if isinstance(backend, StdioBackend):
-                # Command should be a valid Python path
-                assert backend.command
-                # Should be an absolute path or the detected executable
-                assert (
-                    Path(backend.command).is_absolute()
-                    or backend.command == sys.executable
-                )
+        # Default config has no backends to check
+        assert config.backends == {}
 
     def test_get_default_config_portable_paths(self):
-        """Backend paths should be relative to base_path."""
+        """Default config has no backends; paths are user-configured."""
         config = get_default_config()
-        base = get_base_path()
-
-        for backend in config.backends.values():
-            if isinstance(backend, StdioBackend):
-                for arg in backend.args:
-                    if arg.endswith(".py"):
-                        # Python file paths should be under base_path
-                        assert str(base) in arg or not Path(arg).is_absolute()
+        # Default config has no backends - paths are user responsibility
+        assert config.backends == {}
 
 
 class TestLoadConfig:

--- a/tests/test_embedder.py
+++ b/tests/test_embedder.py
@@ -10,9 +10,6 @@ import numpy as np
 from pathlib import Path
 from unittest.mock import Mock, AsyncMock, patch
 import httpx
-import sys
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from embedder import (
     Embedder,

--- a/tests/test_fuzz.py
+++ b/tests/test_fuzz.py
@@ -9,11 +9,7 @@ from hypothesis import given, settings, assume, HealthCheck
 from hypothesis import strategies as st
 from unittest.mock import patch
 import json
-import sys
 from pathlib import Path
-
-# Add parent to path
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 # =============================================================================

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -8,9 +8,6 @@ Based on FastMCP testing patterns: https://gofastmcp.com/patterns/testing
 import pytest
 from pathlib import Path
 from unittest.mock import Mock, AsyncMock, patch
-import sys
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 
 class TestCompassTool:

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -6,9 +6,6 @@ Tests HNSW index building, searching, and metadata management.
 
 import pytest
 from pathlib import Path
-import sys
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from indexer import CompassIndex, SearchResult
 from tool_manifest import ToolDefinition

--- a/tests/test_sync_manager.py
+++ b/tests/test_sync_manager.py
@@ -7,9 +7,6 @@ Tests backend change detection, hash computation, and sync operations.
 import pytest
 from pathlib import Path
 from unittest.mock import Mock, AsyncMock, patch
-import sys
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from sync_manager import SyncManager, get_sync_manager
 from config import CompassConfig, StdioBackend

--- a/tests/test_tool_manifest.py
+++ b/tests/test_tool_manifest.py
@@ -6,9 +6,6 @@ Tests tool definitions, filtering, and export functionality.
 
 import json
 from pathlib import Path
-import sys
-
-sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from tool_manifest import (
     ToolDefinition,


### PR DESCRIPTION
## Summary

Comprehensive audit fixing P0-P2 issues identified in the tool-compass codebase.

### P0 - Must Fix
- **GitHub Actions invalid versions** - Fixed `actions/checkout@v6` → `v4` and `actions/setup-python@v6` → `v5` (v6 doesn't exist)
- **Config path writes inside package** - Added `get_user_config_dir()` for platform-specific user-writable directories
- **README badges pointing to wrong repo** - Changed all `mikeyfrilot/tool-compass` → `mcp-tool-shop/tool-compass`

### P1 - Strongly Recommended
- **setup.py duplication** - Renamed `setup.py` → `bootstrap.py` to avoid confusion with pyproject.toml
- **Default backend paths** - Changed `get_default_config()` to return empty backends; added `get_example_config()` for examples
- **sys.path.insert in tests** - Added `pythonpath = ["."]` to pytest config; removed from 11 test files

### P2 - Nice to Have
- **UI binds to 127.0.0.1** - Already done (no changes needed)
- **Document progressive disclosure** - Added detailed section to README

## Test plan

- [ ] GitHub Actions should now run successfully (previously broken with v6 actions)
- [ ] Tests pass without sys.path.insert hacks
- [ ] Config writes to user directory, not package directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)