### PR TITLE
docs: update badge URLs to mcp-tool-shop-org

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 **Semantic navigator for MCP tools - Find the right tool by intent, not memory**
 
-[![Tests](https://github.com/mikeyfrilot/tool-compass/actions/workflows/test.yml/badge.svg)](https://github.com/mikeyfrilot/tool-compass/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/mikeyfrilot/tool-compass/graph/badge.svg)](https://codecov.io/gh/mikeyfrilot/tool-compass)
+[![Tests](https://github.com/mcp-tool-shop-org/tool-compass/actions/workflows/test.yml/badge.svg)](https://github.com/mcp-tool-shop-org/tool-compass/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/mcp-tool-shop-org/tool-compass/graph/badge.svg)](https://codecov.io/gh/mcp-tool-shop-org/tool-compass)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-blue.svg?logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Docker](https://img.shields.io/badge/docker-ready-blue.svg?logo=docker&logoColor=white)](https://www.docker.com/)
-[![GitHub stars](https://img.shields.io/github/stars/mikeyfrilot/tool-compass?style=social)](https://github.com/mikeyfrilot/tool-compass)
+[![GitHub stars](https://img.shields.io/github/stars/mcp-tool-shop-org/tool-compass?style=social)](https://github.com/mcp-tool-shop-org/tool-compass)
 
 *95% fewer tokens. Find tools by describing what you want to do.*
 


### PR DESCRIPTION
## Summary
- Update badge URLs to point to mcp-tool-shop-org instead of personal account
- Fixes Tests badge, Codecov badge, and GitHub stars badge

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>