### PR TITLE
Add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,15 +44,52 @@ Tool Compass uses **semantic search** to find relevant tools from a natural lang
 
 ## Quick Start
 
-### Option 1: Local Installation
+### Option 1: Homebrew (macOS/Linux) - Recommended
+
+```bash
+# Install via Homebrew
+brew tap mcp-tool-shop-org/mcp-tools
+brew install tool-compass
+
+# Install Ollama (required for embeddings)
+brew install ollama
+ollama pull nomic-embed-text
+
+# Build the search index
+tool-compass --sync
+
+# Run the MCP server
+tool-compass
+
+# Or launch the Gradio UI
+tool-compass-ui
+```
+
+### Option 2: PyPI
+
+```bash
+# Prerequisites: Ollama with nomic-embed-text
+ollama pull nomic-embed-text
+
+# Install from PyPI
+pip install tool-compass
+
+# Build the search index
+tool-compass --sync
+
+# Run the MCP server
+tool-compass
+```
+
+### Option 3: Local Development
 
 ```bash
 # Prerequisites: Ollama with nomic-embed-text
 ollama pull nomic-embed-text
 
 # Clone and setup
-git clone https://github.com/mikeyfrilot/tool-compass.git
-cd tool-compass/tool_compass
+git clone https://github.com/mcp-tool-shop-org/tool-compass.git
+cd tool-compass
 
 # Create virtual environment
 python -m venv venv
@@ -71,7 +108,7 @@ python gateway.py
 python ui.py
 ```
 
-### Option 2: Docker
+### Option 4: Docker
 
 ```bash
 # Clone the repo


### PR DESCRIPTION
## Summary

Adds Homebrew as the **recommended primary installation method** for tool-compass, now that it's available via the official mcp-tool-shop-org Homebrew tap.

## Changes

- ✅ Add Homebrew installation as **Option 1 (Recommended)**
- ✅ Reorganize existing methods:
  - PyPI → Option 2
  - Local Development → Option 3  
  - Docker → Option 4
- ✅ Include Ollama installation via Homebrew
- ✅ Update command examples to use installed binaries (`tool-compass`, `tool-compass-ui`)

## Installation Instructions

Users can now install with:
```bash
brew tap mcp-tool-shop-org/mcp-tools
brew install tool-compass
```

## Related

- Homebrew tap: https://github.com/mcp-tool-shop-org/homebrew-mcp-tools
- Formula: https://github.com/mcp-tool-shop-org/homebrew-mcp-tools/blob/master/Formula/tool-compass.rb