### PR TITLE
ci: add paths filter to reduce Actions cost

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,13 +1,28 @@
 # Tool Compass CI Pipeline
-# Runs tests on every push and PR
+# Runs tests on pushes and PRs that touch code or config
 
 name: Tests
 
 on:
   push:
     branches: [main, develop]
+    paths:
+      - '*.py'
+      - 'tests/**'
+      - 'requirements*.txt'
+      - 'pyproject.toml'
+      - 'Dockerfile'
+      - '.github/workflows/**'
   pull_request:
     branches: [main]
+    paths:
+      - '*.py'
+      - 'tests/**'
+      - 'requirements*.txt'
+      - 'pyproject.toml'
+      - 'Dockerfile'
+      - '.github/workflows/**'
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Adds `paths:` filter to test workflow so the 11-job pipeline (9 matrix + integration + docker) only runs when code or config changes
- Adds `workflow_dispatch:` for manual trigger capability

## Test plan
- [ ] Verify CI triggers on `.py`, `tests/**`, `requirements*.txt`, `pyproject.toml`, `Dockerfile` changes
- [ ] Verify CI does NOT trigger on README-only changes
- [ ] Verify manual workflow dispatch works

🤖 Generated with [Claude Code](https://claude.com/claude-code)