### PR TITLE
chore: pre-swarm tidy (docs + .gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,7 @@ tmpclaude-*
 archive/
 site/.astro/
 site/node_modules/
+
+# forkctl / polyglot-mcp scratch
+.artifact/
+.polyglot-cache.json

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ ollama pull nomic-embed-text
 
 # Clone and setup
 git clone https://github.com/mcp-tool-shop-org/tool-compass.git
-
-cd tool-compass/tool_compass
+cd tool-compass
 
 # Create virtual environment
 python -m venv venv
@@ -82,8 +81,7 @@ python ui.py
 ```bash
 # Clone the repo
 git clone https://github.com/mcp-tool-shop-org/tool-compass.git
-
-cd tool-compass/tool_compass
+cd tool-compass
 
 # Start with Docker Compose (requires Ollama running locally)
 docker-compose up
@@ -303,7 +301,7 @@ Tool Compass is a **local-first** development tool. See [SECURITY.md](SECURITY.m
 | A. Security | 10/10 | SECURITY.md, local-only, no telemetry, parameterized SQL |
 | B. Error Handling | 10/10 | Structured results, graceful Ollama fallback |
 | C. Operator Docs | 10/10 | README, CHANGELOG, CONTRIBUTING, API docs |
-| D. Shipping Hygiene | 10/10 | CI (lint + 413 tests + coverage + pip-audit + Docker), verify script |
+| D. Shipping Hygiene | 10/10 | CI (lint + tests + coverage + pip-audit + Docker), verify script |
 | E. Identity | 10/10 | Logo, translations, landing page |
 | **Total** | **50/50** | |
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ The `hint` field in compass results guides this flow, suggesting when to use `de
 | `TOOL_COMPASS_DATA_DIR` | Data directory | Platform-specific (see below) |
 | `OLLAMA_URL` | Ollama server URL | `http://localhost:11434` |
 | `COMFYUI_URL` | ComfyUI server | `http://localhost:8188` |
+| `PORT` | Set to enable HTTP transport (e.g., for Fly.io) | unset (stdio) |
 
 **Default data directories:**
 - **Windows:** `%LOCALAPPDATA%\tool-compass\`

--- a/site/src/content/docs/handbook/architecture.md
+++ b/site/src/content/docs/handbook/architecture.md
@@ -46,12 +46,39 @@ execute("comfy:comfy_generate", {prompt: "..."})
   → result from backend
 ```
 
+## Subsystems
+
+Beyond the core search pipeline, Tool Compass includes several runtime subsystems:
+
+**Backend client** (`backend_client_simple.py`) — Manages subprocess-based MCP server connections using direct JSON-RPC over stdin/stdout. Includes connection pooling, automatic reconnection, and retry logic. A secondary SDK-based client (`backend_client_mcp.py`) exists for reference but is not used at runtime to avoid anyio task group conflicts.
+
+**Sync manager** (`sync_manager.py`) — Detects when backend servers have added or changed tools by comparing hash digests of tool lists. Supports three strategies: hash-based change detection, on-demand startup check, and optional background polling at a configurable interval.
+
+**Analytics** (`analytics.py`) — Tracks search queries, tool executions, success/failure rates, and latencies in a local SQLite database (`compass_analytics.db`). Arguments are hashed (never stored in plain text). Maintains a hot cache of the top N most-used tools for instant access.
+
+**Chain indexer** (`chain_indexer.py`) — Makes multi-tool workflows (chains) searchable via their own HNSW index. Chains can be manually defined or auto-detected from usage patterns recorded by the analytics engine.
+
+**Embedder** (`embedder.py`) — Async HTTP client for Ollama's embedding API. Uses the `search_document:` prefix when embedding tool descriptions and `search_query:` when embedding user intents, following nomic-embed-text best practices for retrieval tasks. Also provides a `SyncEmbedder` wrapper safe for use inside running event loops (e.g., Gradio callbacks).
+
+## Backend types
+
+Configuration supports three backend connection types, defined in `config.py`:
+
+| Type | Description |
+|------|-------------|
+| `stdio` | Spawns an MCP server as a subprocess and communicates via stdin/stdout JSON-RPC. This is the default and recommended type. |
+| `http` | Connects to a remote MCP server over HTTP/SSE. |
+| `import` | Imports an MCP server module directly into the same Python process. |
+
+Only `stdio` backends are implemented at runtime. `http` and `import` types are defined in the configuration schema for future use.
+
 ## Features
 
-- **Hot cache** — Frequently used tools are pre-loaded for instant access
-- **Chain detection** — Automatically discovers common tool workflows from usage patterns
-- **Analytics** — Tracks usage patterns, accuracy metrics, and performance data in local SQLite
-- **Cross-platform** — Works on Windows, macOS, and Linux
+- **Hot cache** — The top 10 most frequently used tools are kept in memory for instant access
+- **Chain detection** — Automatically discovers common tool workflows from usage patterns, indexing them for semantic search
+- **Analytics** — Tracks search queries, tool calls, success rates, and latencies in local SQLite
+- **Auto-sync** — Detects backend tool changes on startup via hash comparison and rebuilds affected index portions
+- **Cross-platform** — Works on Windows, macOS, and Linux with platform-specific subprocess handling
 
 ## Performance
 

--- a/site/src/content/docs/handbook/beginners.md
+++ b/site/src/content/docs/handbook/beginners.md
@@ -1,0 +1,155 @@
+---
+title: Beginners
+description: First-time setup walkthrough and core concepts for Tool Compass.
+sidebar:
+  order: 99
+---
+
+## What is Tool Compass?
+
+Tool Compass is a semantic navigator for MCP tools. Instead of loading every tool definition into your LLM context (wasting thousands of tokens), Tool Compass indexes your tools and lets you search for the right one by describing what you want to do.
+
+A single `compass()` call replaces loading dozens of tool schemas. The result: around 95% fewer tokens per request with no loss of capability.
+
+## Prerequisites
+
+Before installing Tool Compass you need two things:
+
+1. **Python 3.10 or newer** -- check with `python --version`
+2. **Ollama** running locally with the `nomic-embed-text` model -- this generates the vector embeddings that power semantic search
+
+Install Ollama from [ollama.com](https://ollama.com) and pull the embedding model:
+
+```bash
+ollama pull nomic-embed-text
+```
+
+Verify Ollama is running:
+
+```bash
+curl http://localhost:11434/api/tags
+```
+
+## Installation
+
+Clone the repository and set up a virtual environment:
+
+```bash
+git clone https://github.com/mcp-tool-shop-org/tool-compass.git
+cd tool-compass
+
+python -m venv venv
+source venv/bin/activate  # Windows: venv\Scripts\activate
+
+pip install -r requirements.txt
+```
+
+Build the search index (this embeds all tool descriptions into vectors):
+
+```bash
+python gateway.py --sync
+```
+
+Start the MCP gateway server:
+
+```bash
+python gateway.py
+```
+
+If you prefer Docker, see the [Getting Started](/tool-compass/handbook/getting-started/) page for Docker Compose instructions.
+
+## Core concepts
+
+Tool Compass is built around three ideas:
+
+**Semantic search** -- Tool descriptions are embedded into 768-dimensional vectors using Ollama. When you search, your intent is embedded the same way and compared against all indexed tools using HNSW approximate nearest-neighbor search. This means you can describe what you want in natural language and get back relevant tools even if you do not know their exact names.
+
+**Progressive disclosure** -- Instead of dumping full JSON schemas for every tool, Compass uses a three-step flow that loads detail only when needed:
+
+```
+compass("generate an image")   -> summaries + confidence scores (~2K tokens)
+describe("comfy:comfy_generate") -> full parameter schema (~500 tokens)
+execute("comfy:comfy_generate", {...}) -> run the tool
+```
+
+**Tool chains** -- Common multi-tool workflows (like "read file, modify, write back") are detected from usage patterns and made searchable alongside individual tools.
+
+## First steps after install
+
+Once the gateway is running, try these calls to explore what is available:
+
+1. **Search for tools** -- call `compass()` with a natural language intent:
+
+   ```python
+   compass(intent="read a file from disk")
+   ```
+
+2. **Browse categories** -- call `compass_categories()` to see what kinds of tools exist (file, git, database, ai, search, analysis, etc.)
+
+3. **Inspect a tool** -- pick a tool name from compass results and call `describe()` to see its full schema:
+
+   ```python
+   describe(tool_name="bridge:read_file")
+   ```
+
+4. **Run a tool** -- pass arguments to `execute()`:
+
+   ```python
+   execute(tool_name="bridge:read_file", arguments={"filepath": "README.md"})
+   ```
+
+5. **Check system health** -- call `compass_status()` to see index size, backend connections, and configuration
+
+## Common tasks
+
+**Filtering searches by category** -- If you know you need a git tool, narrow the results:
+
+```python
+compass(intent="commit my changes", category="git")
+```
+
+**Viewing analytics** -- See how tools are being used over the last 24 hours:
+
+```python
+compass_analytics(timeframe="24h")
+```
+
+**Working with tool chains** -- List pre-defined workflows:
+
+```python
+compass_chains(action="list")
+```
+
+Create a custom workflow:
+
+```python
+compass_chains(
+    action="create",
+    chain_name="code_review",
+    tools=["bridge:read_file", "doc:scan", "doc:report"],
+    description="Read a file, scan for issues, generate report"
+)
+```
+
+**Rebuilding the index** -- If you add new backend servers, sync the index:
+
+```python
+compass_sync(force=True)
+```
+
+## Glossary
+
+| Term | Meaning |
+|------|---------|
+| **Backend** | An MCP server that provides tools (e.g., bridge, comfy, doc, video, chat) |
+| **Compass index** | The HNSW vector index that stores tool embeddings for fast similarity search |
+| **Chain** | A named sequence of tools that form a workflow |
+| **Confidence score** | A 0-1 similarity score indicating how well a tool matches your intent |
+| **Gateway** | The Tool Compass MCP server that proxies searches and tool calls to backends |
+| **Hot cache** | The top 10 most frequently used tools, kept in memory for instant access |
+| **HNSW** | Hierarchical Navigable Small World -- the algorithm used for approximate nearest-neighbor vector search |
+| **Intent** | The natural language description you pass to `compass()` |
+| **nomic-embed-text** | The Ollama embedding model that converts text into 768-dimensional vectors |
+| **Progressive disclosure** | The three-step pattern: `compass()` then `describe()` then `execute()` |
+| **Qualified name** | A tool name in `server:tool` format (e.g., `bridge:read_file`) |
+| **Sync** | The process of discovering tools from backends and rebuilding the search index |

--- a/site/src/content/docs/handbook/beginners.md
+++ b/site/src/content/docs/handbook/beginners.md
@@ -58,6 +58,15 @@ python gateway.py
 
 If you prefer Docker, see the [Getting Started](/tool-compass/handbook/getting-started/) page for Docker Compose instructions.
 
+To explore tools interactively in a browser, launch the Gradio UI instead:
+
+```bash
+pip install "tool-compass[ui]"
+python ui.py
+```
+
+This opens a web interface at `http://localhost:7860` where you can search, browse categories, and view analytics.
+
 ## Core concepts
 
 Tool Compass is built around three ideas:
@@ -153,3 +162,9 @@ compass_sync(force=True)
 | **Progressive disclosure** | The three-step pattern: `compass()` then `describe()` then `execute()` |
 | **Qualified name** | A tool name in `server:tool` format (e.g., `bridge:read_file`) |
 | **Sync** | The process of discovering tools from backends and rebuilding the search index |
+
+## What's next
+
+- **[Tools reference](/tool-compass/handbook/tools/)** — Detailed parameter tables for all 9 gateway tools
+- **[Architecture](/tool-compass/handbook/architecture/)** — How the HNSW index, embedder, sync manager, and analytics engine work together
+- **[Configuration](/tool-compass/handbook/configuration/)** — All config file options, environment variables, Docker setup, and troubleshooting

--- a/site/src/content/docs/handbook/configuration.md
+++ b/site/src/content/docs/handbook/configuration.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Environment variables, Docker, and troubleshooting.
+description: Environment variables, config file, Docker, and troubleshooting.
 sidebar:
   order: 4
 ---
@@ -9,13 +9,60 @@ sidebar:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `TOOL_COMPASS_BASE_PATH` | Project root | Auto-detected |
-| `TOOL_COMPASS_PYTHON` | Python executable | Auto-detected |
-| `TOOL_COMPASS_CONFIG` | Config file path | `./compass_config.json` |
+| `TOOL_COMPASS_BASE_PATH` | Project root directory | Auto-detected from module location |
+| `TOOL_COMPASS_PYTHON` | Python executable path | Current interpreter or venv auto-detect |
+| `TOOL_COMPASS_CONFIG` | Path to config JSON file | `./compass_config.json` |
 | `OLLAMA_URL` | Ollama server URL | `http://localhost:11434` |
-| `COMFYUI_URL` | ComfyUI server | `http://localhost:8188` |
+| `COMFYUI_URL` | ComfyUI server URL (used by the comfy backend) | `http://localhost:8188` |
+| `PORT` | Set to enable HTTP (streamable-http) transport instead of stdio | unset (stdio mode) |
 
-See `.env.example` in the repository for all options.
+## Config file
+
+Tool Compass reads settings from a JSON file at startup. The resolution order for the config path is:
+
+1. `TOOL_COMPASS_CONFIG` environment variable
+2. `./compass_config.json` in the tool-compass directory
+
+If no config file is found, built-in defaults are used. See `compass_config.example.json` in the repository for a complete example.
+
+### All config options
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `backends` | object | (built-in defaults) | Backend server connections keyed by name |
+| `embedding_model` | string | `nomic-embed-text` | Ollama embedding model name |
+| `ollama_url` | string | `http://localhost:11434` | Ollama API base URL |
+| `index_dir` | string | `./db` | Directory for HNSW index and SQLite databases |
+| `auto_sync` | bool | `true` | Enable automatic tool discovery from backends |
+| `default_top_k` | int | `5` | Default number of results for compass searches |
+| `min_confidence` | float | `0.3` | Default minimum similarity threshold |
+| `progressive_disclosure` | bool | `true` | Return summaries only from compass (use describe for full schemas) |
+| `sync_check_on_startup` | bool | `true` | Check for backend changes on first compass call |
+| `sync_polling_interval` | int | `300` | Background polling interval in seconds (0 = disabled) |
+| `analytics_enabled` | bool | `true` | Track search queries and tool calls in local SQLite |
+| `hot_cache_size` | int | `10` | Number of frequently used tools to keep in memory |
+| `chain_indexing_enabled` | bool | `true` | Enable tool chain detection and indexing |
+| `chain_detection_min_occurrences` | int | `3` | Minimum pattern occurrences before promoting to a chain |
+| `top_chains_cache_size` | int | `5` | Number of top chains to keep in memory cache |
+
+### Variable substitution
+
+The config file supports `${VAR}` substitution. Values are resolved from environment variables first, then from a `defaults` block in the config file:
+
+```json
+{
+  "defaults": {
+    "BASE": "/home/user/project"
+  },
+  "backends": {
+    "bridge": {
+      "type": "stdio",
+      "command": "python",
+      "args": ["-u", "${BASE}/app/mcp/bridge_mcp_server.py"]
+    }
+  }
+}
+```
 
 ## Docker
 
@@ -65,6 +112,14 @@ Rebuild the index:
 ```bash
 python gateway.py --sync
 ```
+
+### Backend not connecting
+
+If a backend fails to connect, verify:
+
+1. The command in your config file is correct and the script exists
+2. The backend MCP server starts successfully when run standalone
+3. Check gateway logs with `--verbose` for detailed connection errors
 
 ## Security and data scope
 

--- a/site/src/content/docs/handbook/getting-started.md
+++ b/site/src/content/docs/handbook/getting-started.md
@@ -24,7 +24,7 @@ ollama pull nomic-embed-text
 
 # Clone and setup
 git clone https://github.com/mcp-tool-shop-org/tool-compass.git
-cd tool-compass/tool_compass
+cd tool-compass
 
 # Create virtual environment
 python -m venv venv
@@ -44,7 +44,7 @@ python gateway.py
 
 ```bash
 git clone https://github.com/mcp-tool-shop-org/tool-compass.git
-cd tool-compass/tool_compass
+cd tool-compass
 
 # Start with Docker Compose (requires Ollama running locally)
 docker-compose up

--- a/site/src/content/docs/handbook/getting-started.md
+++ b/site/src/content/docs/handbook/getting-started.md
@@ -55,12 +55,34 @@ docker-compose --profile with-ollama up
 # Access the UI at http://localhost:7860
 ```
 
+## CLI flags
+
+The gateway accepts several flags for administration tasks:
+
+| Flag | Description |
+|------|-------------|
+| `--sync` | Discover tools from backend MCP servers and rebuild the HNSW index |
+| `--test` | Run semantic search tests to verify index quality |
+| `--config` | Display current configuration including backends and settings |
+| `--verbose` / `-v` | Enable verbose (DEBUG-level) output |
+
+Running `python gateway.py` with no flags starts the MCP server in stdio mode by default. Set the `PORT` environment variable to switch to HTTP (streamable-http) transport for remote deployment (e.g., Fly.io):
+
+```bash
+PORT=8080 python gateway.py
+```
+
 ## Gradio UI
 
 Tool Compass includes a Gradio web interface for interactive exploration:
 
 ```bash
+# Launch on default port 7860
 python ui.py
+
+# Custom port or public share link
+python ui.py --port 7861
+python ui.py --share
 ```
 
 ## Testing

--- a/site/src/content/docs/handbook/index.md
+++ b/site/src/content/docs/handbook/index.md
@@ -9,6 +9,7 @@ Welcome to the Tool Compass handbook.
 
 ## What's inside
 
+- **[Beginners](/tool-compass/handbook/beginners/)** — First-time setup walkthrough and core concepts
 - **[Getting Started](/tool-compass/handbook/getting-started/)** — Install, build the index, run the gateway
 - **[Tools](/tool-compass/handbook/tools/)** — All 9 gateway tools in detail
 - **[Architecture](/tool-compass/handbook/architecture/)** — How semantic search works under the hood

--- a/site/src/content/docs/handbook/tools.md
+++ b/site/src/content/docs/handbook/tools.md
@@ -7,43 +7,56 @@ sidebar:
 
 ## compass
 
-Semantic search for tools. Describe what you want to do and get back only the relevant tools.
+Semantic search for tools. Describe what you want to do and get back only the relevant tools. Also searches for matching tool chains (workflows).
 
 ```python
 compass(
     intent="I need to generate an AI image from a text description",
     top_k=3,
-    category=None,  # Optional: "file", "git", "database", "ai", etc.
-    min_confidence=0.3
+    category=None,
+    server=None,
+    min_confidence=0.3,
+    include_chains=True
 )
 ```
 
-Returns matched tools with confidence scores, token savings, and hints.
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `intent` | yes | Natural language description of your task |
+| `top_k` | no | Maximum results to return (1-10, default 5) |
+| `category` | no | Filter by category (`file`, `git`, `database`, `ai`, `search`, `analysis`, etc.) |
+| `server` | no | Filter by server (`bridge`, `doc`, `comfy`, `video`, `chat`) |
+| `min_confidence` | no | Minimum similarity score (0-1, default 0.3) |
+| `include_chains` | no | Also search for matching workflows (default true) |
+
+Returns matched tools with confidence scores, token savings, hints, and any matching chains.
 
 ## describe
 
-Get full JSON schema for a specific tool before calling it.
+Get the full JSON schema for a specific tool before calling it. This is the second step in the progressive disclosure flow.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
 | `tool_name` | yes | Fully qualified tool name (e.g., `comfy:comfy_generate`) |
 
+Returns full tool schema including parameters, types, examples, and a hint for next steps.
+
 ## execute
 
-Run any indexed tool directly through the gateway.
+Run any indexed tool directly through the gateway. This proxies the call to the appropriate MCP backend server.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `tool_name` | yes | Tool to execute |
-| `args` | yes | Arguments to pass to the tool |
+| `tool_name` | yes | Tool to execute (e.g., `bridge:read_file`) |
+| `arguments` | no | Arguments to pass to the tool as a dictionary |
 
 ## compass_categories
 
-List all tool categories and connected MCP servers. Takes no arguments.
+List all tool categories and connected MCP servers. Use this to understand what kinds of tools are available before searching. Takes no arguments.
 
 ## compass_status
 
-System health and config — index size, model status, configuration. Takes no arguments.
+System health and configuration overview. Returns index stats, backend connection status, hot cache status, sync status, and chain info. Takes no arguments.
 
 ## compass_analytics
 
@@ -51,24 +64,35 @@ Usage statistics, accuracy metrics, and performance data.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `timeframe` | no | Time window for analytics (e.g., `24h`, `7d`) |
+| `timeframe` | no | Time window (`1h`, `24h`, `7d`, `30d`, default `24h`) |
+| `include_failures` | no | Include details about failed tool calls (default true) |
+
+Returns search stats, top tools, success rates, failure details, chain stats, and hot cache info.
 
 ## compass_chains
 
-Discover and manage common multi-tool workflows.
+Discover and manage common multi-tool workflows. Chains are auto-detected from usage patterns or manually defined.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `action` | yes | Action to perform on chain data |
+| `action` | no | `list` (default), `create`, or `detect` |
+| `chain_name` | for create | Name for the new chain |
+| `tools` | for create | Ordered list of tool names |
+| `description` | no | Description for the new chain |
 
 ## compass_sync
 
-Rebuild the HNSW search index from connected backends.
+Rebuild the HNSW search index from connected backends. Normally sync happens automatically on startup.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `force` | no | Force full rebuild even if index exists |
+| `force` | no | Force full rebuild even if no changes detected (default false) |
 
 ## compass_audit
 
-Full system diagnostic — index integrity, server health, configuration validation. Takes no arguments.
+Comprehensive system diagnostic covering index integrity, backend health, hot cache, chains, analytics, and configuration.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `include_tools` | no | Include full list of all indexed tools (default false) |
+| `timeframe` | no | Timeframe for analytics (`1h`, `24h`, `7d`, `30d`, default `24h`) |


### PR DESCRIPTION
## Summary
Pre-flight cleanup before launching a dogfood swarm on this repo.

- Cherry-pick two `docs: audit handbook + README, add beginner section` commits from old `audit/sha-pin-version-tests` branch (beginners.md, handbook edits, README beginner section)
- Add `.artifact/` + `.polyglot-cache.json` to `.gitignore` (forkctl/polyglot-mcp scratch output)

Conflicts resolved against main:
- `README.md` clone step: kept `cd tool-compass` (the `tool_compass/` subdir referenced on main doesn't exist)
- `README.md` config reference: kept `.env.example` + default data directories from main (richer than the cherry-picked version)

## Test plan
- [x] `git status` clean after commits
- [ ] CI green
- [ ] Merge, then tag save point for swarm

🤖 Generated with [Claude Code](https://claude.com/claude-code)