### PR TITLE
fix: tool-compass --version (v2.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Tool Compass will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2026-04-23
+
+Patch release. Fixes the v2.2.0 release-smoke defect.
+
+### Fixed
+- `tool-compass --version` now prints the version and exits. v2.2.0's new
+  CLI subcommand shell (MCC-FT-001) forgot to wire `--version` on the root
+  parser, so the publish-time release-smoke check failed even though the
+  artifacts themselves were valid. Purely a CLI ergonomics fix.
+
 ## [2.2.0] - 2026-04-23
 
 Dogfood swarm release: Stage A bug/security health pass + Stage B/C humanization

--- a/cli.py
+++ b/cli.py
@@ -31,6 +31,17 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="tool-compass",
         description="Semantic MCP tool discovery gateway",
     )
+    # --version lives on the root parser (not a subcommand) so release-smoke
+    # and `tool-compass --version` work out of the box.
+    try:
+        from _version import __version__ as _tc_version
+    except ImportError:  # pragma: no cover — defensive fallback
+        _tc_version = "unknown"
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"tool-compass {_tc_version}",
+    )
     sub = parser.add_subparsers(dest="command", metavar="COMMAND")
 
     # doctor — environment snapshot (delegates to config.doctor()).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tool-compass"
-version = "2.2.0"
+version = "2.2.1"
 description = "Semantic MCP tool discovery gateway - find tools by intent, not memory"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

v2.2.0's CLI subcommand shell ([#68](https://github.com/mcp-tool-shop-org/tool-compass/pull/68)) forgot to wire `--version` on the root argparse parser. Release-smoke job on v2.2.0 caught it — PyPI + GHCR artifacts shipped fine, but `tool-compass --version` returned \`usage: tool-compass [-h] COMMAND ...\` / \`error: unrecognized arguments: --version\`.

## Fix

One argparse call on the root parser in \`cli.py\`, reading from \`_version.__version__\` (which uses \`importlib.metadata.version(\"tool-compass\")\` when installed, pyproject fallback when editable).

Version bumped 2.2.0 → 2.2.1 with CHANGELOG entry.

## Test plan
- [x] \`python cli.py --version\` prints the version and exits 0 locally
- [ ] CI green
- [ ] Merge → tag v2.2.1 → publish.yml re-runs → release-smoke green

🤖 Generated with [Claude Code](https://claude.com/claude-code)