### PR TITLE
fix(docker): install package in image so tool-compass CLI is on PATH (v2.2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to Tool Compass will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2026-04-23
+
+Patch release. Fixes the Docker image so the `tool-compass` console script
+is actually installed inside the container (was missing in v2.2.0/v2.2.1).
+
+### Fixed
+- Docker image now runs `pip install --no-deps .` during build, so
+  `docker run ghcr.io/mcp-tool-shop-org/tool-compass:2.2.2 tool-compass --version`
+  (or any subcommand) works out of the box. v2.2.0/v2.2.1 images only
+  shipped the source tree; the console script was never registered on
+  PATH.
+- Dockerfile `LABEL version` bumped 2.0.7 → 2.2.2.
+
 ## [2.2.1] - 2026-04-23
 
 Patch release. Fixes the v2.2.0 release-smoke defect.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Copy requirements first for layer caching
 COPY requirements.txt .
-COPY pyproject.toml .
+COPY pyproject.toml README.md LICENSE ./
 COPY cli.py gateway.py ui.py indexer.py embedder.py chain_indexer.py \
      analytics.py config.py sync_manager.py tool_manifest.py \
      bootstrap.py backend_client_simple.py backend_client_mcp.py \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Copy requirements first for layer caching
 COPY requirements.txt .
+COPY pyproject.toml .
+COPY cli.py gateway.py ui.py indexer.py embedder.py chain_indexer.py \
+     analytics.py config.py sync_manager.py tool_manifest.py \
+     bootstrap.py backend_client_simple.py backend_client_mcp.py \
+     _version.py llms.txt compass_config.example.json ./
 
-# Create virtualenv and install dependencies
+# Create virtualenv, install deps, and install the package itself so
+# the `tool-compass` console script ends up on PATH (ships with the image).
 RUN python -m venv /opt/venv
 ENV PATH="/opt/venv/bin:$PATH"
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt && \
-    pip install --no-cache-dir uvicorn
+    pip install --no-cache-dir uvicorn && \
+    pip install --no-cache-dir --no-deps .
 
 # =============================================================================
 # Stage 2: Production
@@ -31,7 +38,7 @@ FROM python:3.11-slim AS production
 LABEL maintainer="Tool Compass <github.com/mcp-tool-shop-org/tool-compass>"
 LABEL description="Semantic search gateway for MCP tools"
 # Keep in sync with pyproject.toml [project] version
-LABEL version="2.0.7"
+LABEL version="2.2.2"
 
 # Security: Run as non-root user
 RUN groupadd -r compass && useradd -r -g compass compass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tool-compass"
-version = "2.2.1"
+version = "2.2.2"
 description = "Semantic MCP tool discovery gateway - find tools by intent, not memory"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary

v2.2.1's release-smoke caught: Docker image has no \`tool-compass\` on PATH. The image only copied sources + installed \`requirements.txt\`; never ran \`pip install .\`. So \`docker run ... tool-compass --version\` exits with \`executable file not found\`.

## Fix

Builder stage now:
1. Copies Python sources + pyproject.toml
2. Runs \`pip install --no-deps .\` alongside the existing \`pip install -r requirements.txt\`

Default CMD unchanged (\`python gateway.py\`), so image behavior for users who just \`docker run <image>\` is identical. Users who want \`docker run <image> tool-compass <sub>\` now get it.

Bumps version 2.2.1 → 2.2.2 + Dockerfile \`LABEL version\` 2.0.7 → 2.2.2.

## Test plan
- [ ] CI green
- [ ] Merge → tag v2.2.2 → publish.yml → release-smoke Docker step green

🤖 Generated with [Claude Code](https://claude.com/claude-code)