### PR TITLE
fix(release): exclude mcp.cli+typer from PyInstaller hidden imports

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -78,7 +78,12 @@ jobs:
           pyinstaller --onefile \
             --name "${{ env.TOOL_NAME }}" \
             --console \
-            --collect-submodules mcp \
+            --collect-submodules mcp.client \
+            --collect-submodules mcp.server \
+            --collect-submodules mcp.types \
+            --collect-submodules mcp.shared \
+            --exclude-module mcp.cli \
+            --exclude-module typer \
             --collect-submodules hnswlib \
             --collect-submodules numpy \
             --collect-submodules httpx \


### PR DESCRIPTION
## Summary

Fixes the v2.3.0 \`release-binaries.yml\` failure on all 3 platforms:

\`\`\`
RuntimeError: Child process call to _collect_submodules() failed with:
  File ".../mcp/cli/cli.py", line 15, in <module>
    import typer
ModuleNotFoundError: No module named 'typer'
\`\`\`

\`--collect-submodules mcp\` pulled in \`mcp.cli\` (a CLI for MCP server development) which needs \`typer\` from the \`mcp[cli]\` optional extra. tool-compass only uses \`mcp.client\`, \`mcp.server\`, \`mcp.types\`, \`mcp.shared\` — narrow the submodule collection to just those and explicitly exclude \`mcp.cli\` + \`typer\`.

## Test plan
- [x] Local PyInstaller invocation succeeds with the narrowed flags
- [ ] CI release-binaries.yml workflow_dispatch on tag v2.3.0 succeeds
- [ ] All 3 platform binaries upload to the v2.3.0 GH Release
- [ ] checksums-2.3.0.txt generates and uploads
- [ ] publish-npm job runs and publishes @mcptoolshop/tool-compass@2.3.0

## Re-trigger plan after merge

\`\`\`bash
gh workflow run release-binaries.yml --ref main -f tag=v2.3.0
\`\`\`

This dispatches the workflow against the v2.3.0 tag with the fixed entry script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)