### PR TITLE
fix(release): correct actions/download-artifact SHA pin

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -78,7 +78,12 @@ jobs:
           pyinstaller --onefile \
             --name "${{ env.TOOL_NAME }}" \
             --console \
-            --collect-submodules mcp \
+            --collect-submodules mcp.client \
+            --collect-submodules mcp.server \
+            --collect-submodules mcp.types \
+            --collect-submodules mcp.shared \
+            --exclude-module mcp.cli \
+            --exclude-module typer \
             --collect-submodules hnswlib \
             --collect-submodules numpy \
             --collect-submodules httpx \

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -118,7 +118,7 @@ jobs:
       contents: write
     steps:
       - name: Download all binaries
-        uses: actions/download-artifact@d3f86a106a0bac45b6f43a9e15dcdfde08ad5097 # v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
Bad SHA in release-binaries.yml — d3f86a1... doesn't resolve in the action registry. Replace with the valid v8.0.1 SHA (3e5f45b2...) that publish.yml already uses successfully.

Unblocks the v2.3.0 release-binaries retry — PyInstaller built all 3 binaries successfully (after #81), but the attach job couldn't download them because of this typo SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)