### PR TITLE
chore: bump GH Actions to Node 24-compatible releases (Sep 2026 deadline)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
         # SHA-pinned per SLSA L3 supply-chain hygiene (CT-B-001). nightly-fuzz
         # carries issues:write, so a compromised v7 mutable tag would inherit
         # issue-creation capability. Bump via dependabot's github-actions sweep.
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = `[nightly-fuzz] Hypothesis failures on ${context.sha}`;

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -156,7 +156,7 @@ jobs:
           ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
Mechanical sweep ahead of GitHub's Node 24 transition. Node 20 actions emit a deprecation warning today; on Jun 2, 2026 Node 24 becomes the default runtime, and on Sep 16, 2026 Node 20 actions stop working entirely.

**Bumps:**
- `actions/checkout` v4 → v6.0.2 (`de0fac2e4500dabe0009e67214ff5f5447ce83dd`)
- `actions/setup-node` v4 → v6.4.0 (`48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e`)
- `actions/upload-artifact` v4 → v7.0.1 (`043fb46d1a93c77aae656e7c1c64a875d1fc6a0a`)
- `actions/download-artifact` v4 → v7.0.0 (`37930b1c2abaa49bbe596cd826c3c89aef350131`)
- `actions/cache` v4 → v5.0.5 (`27d5ce7f107fe9357f9df03efb73ab90386fccae`)
- `actions/github-script` v7 → v9.0.0 (`3a2844b7e9c422d3c10d287c895573f7108da1b3`)

**Breaking-change audit:**
- `upload-artifact` v5→v7: no breaking changes for typical `name`/`path`/`retention-days` usage
- `download-artifact`: held at **v7** rather than v8 — v8 changed default auto-unzip behavior, conservative bump avoids that risk
- `github-script` v9: safe unless any inline script does `require('@actions/github')` or shadows `getOctokit` — grep across the org showed neither pattern in use

**SHA + version-comment pinning convention preserved.** All pins remain hard-pinned to the commit SHA with a `# vX.Y.Z` comment, matching the org's existing supply-chain hardening style.