### PR TITLE
chore: bump third-party GH Actions to Node 24-compatible releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,7 +131,7 @@ jobs:
         # SHA-pinned per SLSA L3 supply-chain hygiene (CT-B-002). publish job
         # carries packages:write — a compromised mutable v3 tag would inherit
         # GHCR write capability during a release window. Bump via dependabot.
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -134,7 +134,7 @@ jobs:
           cat "checksums-${VERSION}.txt"
 
       - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ github.event.release.tag_name || inputs.tag }}
           files: artifacts/*


### PR DESCRIPTION
Third-party sweep ahead of GitHub's Node 24 transition. The previous sweep covered the `actions/*` namespace; this one covers third-party actions that still ran on Node 20 (or older). Latest `gh api action.yml` runtime confirmed for each target version.

**Bumps:**
- `docker/setup-qemu-action` v3 → v4.0.0
- `softprops/action-gh-release` v2.3.2 → v3.0.0

**Files:**
- `.github/workflows/publish.yml`
- `.github/workflows/release-binaries.yml`

**Runtime audit (current pin → target pin):**
- `softprops/action-gh-release` v1 (Node 16!) / v2.x (Node 20) → v3.0.0 (Node 24)
- `astral-sh/setup-uv` v3 (Node 16!) / v5.x (Node 20) → v8.1.0 (Node 24)
- `pnpm/action-setup` v3 / v4 (Node 20) → v6.0.8 (Node 24)
- `docker/login-action` v3 (Node 20) → v4.2.0 (Node 24)
- `docker/build-push-action` v6 (Node 20) → v7.2.0 (Node 24)
- `docker/setup-buildx-action` v3 (Node 20) → v4.1.0 (Node 24)
- `docker/setup-qemu-action` v3.x (Node 20) → v4.0.0 (Node 24)
- `docker/metadata-action` v5 (Node 20) → v6.1.0 (Node 24)

Only the action versions you have pinned are bumped — `pnpm/action-setup@v5`, `docker/login-action@v4*`, etc. already run on Node 24 and are left alone.

**SHA + version-comment pinning convention preserved.** All pins remain hard-pinned to commit SHA with `# vX.Y.Z` comment, matching the org's supply-chain hardening style.
