### PR TITLE
ci: bump Actions to Node 24 (June 16 deprecation)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -131,7 +131,7 @@ jobs:
         # SHA-pinned per SLSA L3 supply-chain hygiene (CT-B-002). publish job
         # carries packages:write — a compromised mutable v3 tag would inherit
         # GHCR write capability during a release window. Bump via dependabot.
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -134,7 +134,7 @@ jobs:
           cat "checksums-${VERSION}.txt"
 
       - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@72f2c25fcb47643c292f7107632f7a47c1df5cd8 # v2.3.2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           tag_name: ${{ github.event.release.tag_name || inputs.tag }}
           files: artifacts/*


### PR DESCRIPTION
Bumps 2 Node-20 action pin(s) to their latest Node-24 SHA-pinned releases ahead of GitHub's 2026-06-16 forced-Node-24 cutover.

Actions: docker/setup-qemu-action, softprops/action-gh-release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)