### PR TITLE
fix(analytics): make lazy DB connection init thread-safe (fixes flaky CI)

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -108,6 +108,16 @@ class CompassAnalytics:
         # via check_same_thread=False; we serialize writes ourselves).
         self._lock = threading.Lock()
 
+        # MCC-FT-003: dedicated lock for lazy connection initialization. The
+        # write lock (self._lock) does NOT cover _get_db()/_init_db, so two
+        # threads first-touching the DB concurrently used to race here — each
+        # saw self.db is None, each opened a connection and ran the DDL,
+        # interleaving CREATE + commit on a shared handle and corrupting
+        # transaction state ("cannot commit - no transaction is active"). A
+        # separate init lock keeps that serialization orthogonal to the write
+        # path (writers never block on init once the connection is published).
+        self._init_lock = threading.Lock()
+
         # Session tracking for chain detection. Use a bounded deque so a long
         # session never drops middle items on truncation — patterns are saved
         # before the window slides.
@@ -133,13 +143,23 @@ class CompassAnalytics:
         (analytics + sync_manager + chain_indexer) needs both to not race
         for the file lock.
         """
+        # MCC-FT-003: double-checked locking. The fast path (already
+        # initialized) takes no lock. On first touch, serialize under
+        # self._init_lock and publish self.db ONLY after the connection is
+        # fully built + schema-initialized, so a concurrent caller never
+        # observes a half-constructed connection. _init_db operates on the
+        # local `conn` (not self.db) precisely so nothing is visible until
+        # it is complete.
         if self.db is None:
-            self.db = sqlite3.connect(
-                str(self.db_path), check_same_thread=False
-            )
-            self.db.row_factory = sqlite3.Row
-            self._apply_sqlite_pragmas(self.db)
-            self._init_db()
+            with self._init_lock:
+                if self.db is None:
+                    conn = sqlite3.connect(
+                        str(self.db_path), check_same_thread=False
+                    )
+                    conn.row_factory = sqlite3.Row
+                    self._apply_sqlite_pragmas(conn)
+                    self._init_db(conn)
+                    self.db = conn
         return self.db
 
     @staticmethod
@@ -157,10 +177,14 @@ class CompassAnalytics:
         except sqlite3.Error as e:
             logger.debug(f"sqlite PRAGMA setup failed: {e}")
 
-    def _init_db(self):
-        """Initialize analytics database with all tables."""
-        db = self._get_db()
+    def _init_db(self, db: sqlite3.Connection):
+        """Initialize analytics database with all tables.
 
+        MCC-FT-003: takes the connection explicitly rather than calling
+        _get_db(). During lazy init the connection is not yet published to
+        self.db (so a concurrent reader can't see a half-built handle); this
+        method must operate on the passed-in `db` for that to hold.
+        """
         db.executescript("""
             -- Search query tracking
             CREATE TABLE IF NOT EXISTS search_queries (
@@ -264,12 +288,19 @@ class CompassAnalytics:
             (str(CURRENT_SCHEMA_VERSION),),
         )
         db.commit()
-        self._run_migrations()
+        self._run_migrations(db)
         logger.info(f"Analytics database initialized at {self.db_path}")
 
-    def get_schema_version(self) -> int:
-        """Return the current analytics DB schema version (MCC-B-003)."""
-        db = self._get_db()
+    def get_schema_version(
+        self, db: Optional[sqlite3.Connection] = None
+    ) -> int:
+        """Return the current analytics DB schema version (MCC-B-003).
+
+        Accepts an optional connection so it can be called during lazy init
+        (before self.db is published — MCC-FT-003); falls back to _get_db()
+        for ordinary public use.
+        """
+        db = db if db is not None else self._get_db()
         row = db.execute(
             "SELECT value FROM schema_meta WHERE key = 'schema_version'"
         ).fetchone()
@@ -280,15 +311,18 @@ class CompassAnalytics:
         except (KeyError, TypeError, ValueError):
             return 0
 
-    def _run_migrations(self) -> None:
+    def _run_migrations(self, db: Optional[sqlite3.Connection] = None) -> None:
         """Apply any pending schema migrations.
 
         Schema version 1 is the initial shape; there is nothing to migrate
         yet. The hook exists so future changes (new columns, new tables,
         value backfills) can land without scattering conditional logic
         across the codebase. See module docstring for the pattern.
+
+        MCC-FT-003: accepts an optional connection so it runs against the
+        in-flight connection during lazy init, before self.db is published.
         """
-        current = self.get_schema_version()
+        current = self.get_schema_version(db)
         if current == CURRENT_SCHEMA_VERSION:
             logger.debug(
                 f"Analytics schema version {current}; no migrations needed"

--- a/tests/test_regressions_swarm_01.py
+++ b/tests/test_regressions_swarm_01.py
@@ -25,6 +25,7 @@ Findings covered:
 
 import asyncio
 import threading
+import time
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -429,3 +430,104 @@ class TestMCCA005ConcurrentRecordSearch:
             "SELECT COUNT(*) FROM search_queries WHERE query IN ('thread-1','thread-2')"
         ).fetchone()[0]
         assert count == 2
+
+
+# =============================================================================
+# MCC-FT-003: lazy DB init must be race-free on concurrent first-touch
+# =============================================================================
+
+
+class TestMCCFT003ConcurrentFirstTouchInit:
+    """Deterministic regression for the init-race root cause behind the
+    flaky MCC-A-005 failure.
+
+    ``_get_db()`` lazily opens the sqlite connection and runs ``_init_db``
+    (DDL + commit). That path is NOT covered by the write lock. Before the
+    fix, two threads first-touching the DB simultaneously each saw
+    ``self.db is None``, each opened its own connection, and interleaved
+    ``CREATE TABLE`` + ``commit`` on the shared handle — corrupting
+    transaction state ("cannot commit - no transaction is active"). One
+    thread got marked degraded and its write was lost, so only one of the
+    two rows landed (the ``assert 1 == 2`` seen in CI under coverage, which
+    widens the race window via tracing).
+
+    The plain MCC-A-005 test is timing-dependent — on a fast host both
+    threads can serialize past the window and it passes even when the bug is
+    present. This test makes the failure DETERMINISTIC by slowing
+    ``sqlite3.connect`` so every racing thread is guaranteed to be inside the
+    init window at once, then asserts the load-bearing invariant: lazy init
+    creates EXACTLY ONE shared connection no matter how many threads
+    first-touch concurrently. Pre-fix that count is > 1 (and analytics
+    degrades, dropping rows); post-fix it is exactly 1 and every write lands.
+    """
+
+    def test_concurrent_first_touch_opens_single_connection(
+        self, temp_analytics_db, monkeypatch
+    ):
+        import analytics as analytics_mod
+
+        analytics = analytics_mod.CompassAnalytics(
+            db_path=temp_analytics_db,
+            hot_cache_size=5,
+            chain_min_occurrences=2,
+        )
+
+        # Slow the real connect so all barrier-released threads are inside
+        # the lazy-init window simultaneously — turns the timing-dependent
+        # race into a guaranteed one. Patch the module's sqlite3 reference so
+        # only analytics connections are affected.
+        real_connect = analytics_mod.sqlite3.connect
+        connect_count = 0
+        count_lock = threading.Lock()
+
+        def slow_connect(*args, **kwargs):
+            nonlocal connect_count
+            with count_lock:
+                connect_count += 1
+            time.sleep(0.05)
+            return real_connect(*args, **kwargs)
+
+        monkeypatch.setattr(analytics_mod.sqlite3, "connect", slow_connect)
+
+        n_threads = 6
+        barrier = threading.Barrier(n_threads)
+        errors: list[BaseException] = []
+
+        def worker(i: int):
+            try:
+                barrier.wait(timeout=5)
+                asyncio.run(
+                    analytics.record_search(
+                        query=f"first-touch-{i}",
+                        results=[],
+                        latency_ms=1.0,
+                    )
+                )
+            except BaseException as exc:  # noqa: BLE001 — capture everything
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=worker, args=(i,)) for i in range(n_threads)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert all(
+            not t.is_alive() for t in threads
+        ), "a worker did not finish within 10s (deadlock?)"
+        assert not errors, f"concurrent first-touch raised: {errors!r}"
+
+        # Load-bearing invariant: ONE connection, regardless of N racers.
+        assert connect_count == 1, (
+            f"lazy init opened {connect_count} connections under concurrent "
+            "first-touch; expected exactly 1 (init race regressed)"
+        )
+        # No write was lost to a degraded-mode short-circuit.
+        assert analytics._degraded is False
+        db = analytics._get_db()
+        count = db.execute("SELECT COUNT(*) FROM search_queries").fetchone()[0]
+        assert count == n_threads
+
+        analytics.close()


### PR DESCRIPTION
## Root cause

The Python test job's **coverage step** was failing on `main` — not on a coverage threshold (coverage passes at ~86.7% ≥ 80%), but on a single concurrency test:

```
FAILED tests/test_regressions_swarm_01.py::TestMCCA005ConcurrentRecordSearch::test_two_threads_recording_searches_do_not_raise - assert 1 == 2
WARNING analytics:analytics.py:308 Analytics write failed (record_search): cannot commit - no transaction is active.
```

`CompassAnalytics._get_db()` lazily opens the `sqlite3` connection and runs `_init_db` (DDL + commit). That path was **not** covered by `self._lock` (which only guards writes). When two threads first-touch the DB concurrently, each sees `self.db is None`, each opens its own connection, and the `CREATE TABLE` + `commit` calls interleave on the shared handle — corrupting transaction state (`cannot commit - no transaction is active`). One thread is then marked *degraded* and silently drops its write, so only **one** of the two rows lands → `assert 1 == 2`.

It only surfaced on the **coverage** step because `sys.settrace` instrumentation slows execution enough to widen the race window. The plain `Run tests` step (no coverage) raced past it and passed, which is why the visible pytest tests looked green.

> Note: the coverage step is gated `if: matrix.python-version == '3.11'`, so the red check is literally **Python 3.11**; the bug itself is Python-version-agnostic. Reproduced and fixed under **Python 3.12** per the request (and re-verified on the full suite).

## Fix

- Guard lazy init with a dedicated `self._init_lock` using **double-checked locking**, publishing `self.db` only **after** the connection is fully built + schema-initialized — so a concurrent caller never observes a half-built handle.
- `_init_db` / `_run_migrations` / `get_schema_version` now take the connection explicitly, so they operate on the in-flight handle during init instead of re-entering `_get_db()`.
- Fast path (already initialized) still takes **no lock**; writers never block on init once the connection is published. Write serialization (`self._lock`) is unchanged.

## Honest coverage note

This is **not** a coverage-threshold fix and the threshold was **not** lowered. The 80% `fail_under` gate is met (total **86.6%** on 3.12). The fix is a real concurrency bug fix plus a new test.

## New regression test

`TestMCCFT003ConcurrentFirstTouchInit` is **deterministic**: it slows `sqlite3.connect` so every racing thread is guaranteed inside the init window, then asserts exactly **one** connection is opened on concurrent first-touch.

- Pre-fix: **fails** — opens 6 connections, analytics degrades, rows lost.
- Post-fix: **passes** — exactly 1 shared connection, all writes land.

The existing timing-flaky `TestMCCA005ConcurrentRecordSearch` is kept and now passes reliably.

## Verification (local, Python 3.12.13)

- `pytest -m "not integration"` → **985 passed, 3 skipped**
- `pytest --cov=. --cov-report=term -m "not integration"` → **985 passed**, `Required test coverage of 80.0% reached. Total coverage: 86.56%`
- New test verified to fail on pre-fix `analytics.py` and pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)